### PR TITLE
이메일 인증 함수 배포 url 미인증 사태 해결 & 다이어리 전체 보기 페이지 로딩 상태 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,7 +2,7 @@
 import useAuthStore from "@/store/authStore";
 import { User } from "@/types/iadmin";
 import api from "@/utils/api";
-import { AxiosError } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 
 // 로그인 처리 함수 //!에러 처리 필요
 export const login = async (username: string, password: string) => {
@@ -82,5 +82,42 @@ export const getUser = () => {
     return response;
   } catch (error) {
     console.error("회원정보를 가지고 오는데 실패했습니다!", error);
+  }
+};
+
+// 회원가입 메일 인증 요청
+interface ErrorResponse {
+  message?: string;
+  code?: string | number;
+}
+
+export const verifyEmail = async (
+  token: string
+): Promise<{ success: boolean; message: string }> => {
+  try {
+    const response: AxiosResponse<void> = await api.post(
+      `/member/verify-email?token=${token}`
+    );
+    console.log("이메일 인증 성공:", response.status);
+    return { success: true, message: "이메일 인증이 완료되었습니다." };
+  } catch (error) {
+    const axiosError = error as AxiosError<ErrorResponse>;
+    console.error("이메일 인증 실패:", axiosError.response?.status, axiosError);
+
+    let errorMessage = "이메일 인증에 실패했습니다.";
+
+    if (axiosError.response?.status === 404) {
+      errorMessage = "유효하지 않은 인증 링크입니다.";
+    } else if (axiosError.response?.status === 400) {
+      errorMessage = "잘못된 요청입니다. 다시 시도해주세요.";
+    } else if (axiosError.message === "Network Error") {
+      errorMessage = "네트워크 연결에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    } else if (axiosError.response?.data?.message) {
+      errorMessage = axiosError.response.data.message;
+    } else if (axiosError.response?.data?.code) {
+      errorMessage = `오류 코드: ${axiosError.response.data.code}. 관리자에게 문의해주세요.`;
+    }
+
+    return { success: false, message: errorMessage };
   }
 };

--- a/src/app/(route)/diary/everydiary/page.tsx
+++ b/src/app/(route)/diary/everydiary/page.tsx
@@ -19,20 +19,23 @@ function EveryDiary() {
   const page = useDiaryStore((state) => state.page);
   const hasMore = useDiaryStore((state) => state.hasMore);
   const getDiaryList = useDiaryStore((state) => state.getDiaryList);
+  const isLoading = useDiaryStore((state) => state.isLoading);
 
   const router = useRouter();
 
   useEffect(() => {
-    if (diaryList.length === 0) {
+    if (diaryList.length === 0 && !isLoading) {
+      // 데이터가 없고 로딩 중이 아닐 때만 요청
       getDiaryList(page);
-    }
-  }, []);
+    } // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [diaryList.length, page, isLoading, getDiaryList]);
 
   const handleScroll = () => {
     if (
       window.innerHeight + document.documentElement.scrollTop ===
         document.documentElement.offsetHeight &&
-      hasMore
+      hasMore &&
+      !isLoading
     ) {
       const currentPage = useDiaryStore.getState().page;
       getDiaryList(currentPage);
@@ -42,7 +45,8 @@ function EveryDiary() {
   useEffect(() => {
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [hasMore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasMore, isLoading]);
 
   const handleCardClick = (id: number | undefined) => {
     if (id !== undefined) {

--- a/src/store/diaryStore.ts
+++ b/src/store/diaryStore.ts
@@ -20,15 +20,23 @@ interface DiaryState {
   diaryList: Article[];
   page: number;
   hasMore: boolean;
+  isLoading: boolean;
   getDiaryList: (page: number) => Promise<void>;
   resetDiaryList: () => void;
 }
 
-const useDiaryStore = create<DiaryState>((set) => ({
+const useDiaryStore = create<DiaryState>((set, get) => ({
   diaryList: [],
   page: 0,
   hasMore: true,
+  isLoading: false,
   getDiaryList: async (page) => {
+    if (get().isLoading) {
+      // 이미 로딩 중이면 요청하지 않음
+      console.log("이미 로딩 중입니다. 중복 요청을 방지합니다.");
+      return;
+    }
+    set({ isLoading: true }); // 로딩 시작 상태로 변경
     console.log("API 요청 페이지:", page);
     try {
       const response = await api.get(`/article/list`, {
@@ -40,12 +48,15 @@ const useDiaryStore = create<DiaryState>((set) => ({
         diaryList: [...state.diaryList, ...newData],
         page: page + 1,
         hasMore: newData.length > 0, // 데이터가 더 있는지 확인
+        isLoading: false,
       }));
     } catch (error) {
       console.error("일기 목록을 불러오는 중 오류가 발생했습니다.", error);
+      set({ isLoading: false });
     }
   },
-  resetDiaryList: () => set({ diaryList: [], page: 0, hasMore: true }),
+  resetDiaryList: () =>
+    set({ diaryList: [], page: 0, hasMore: true, isLoading: false }),
 }));
 
 export default useDiaryStore;


### PR DESCRIPTION
## 어떤 기능인가요?

> 이메일 인증 함수  & 다이어리 전체 보기 페이지

## 작업 상세 내용

- [ ] 이메일 인증 함수 부분 모듈화 및 api 수정
- [ ] 다이어리 전체 리스트 페이지 s3 번들링 시 js로 전환되면서 이전에 고친 중복 요청 재발
- [ ] 개발환경에서 다이어리 리스트 페이지 받아오면서 로딩상태 또한 전역상태에 추가하고, 실제 api 요청시 로딩이 한번 끝날때까지는 중복 요청 안가게끔 수정. 배포환경에서 확인해봐야함**

Close #63 