### PR TITLE
권한 부여 API 연동 및 선택 박스 UI 수정 

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,26 @@
+import { User } from "@/types/iadmin";
+import api from "@/utils/api";
+
+// 회원 정보 all get 요청!
+export const getUserInfo = async (): Promise<User[]> => {
+  try {
+    const response = await api.get("/admin/userlist");
+    console.log("유저 정보", response);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+// 관리자 페이지 역할 부여 요청 API
+export const postAddRole = async (nickname: string, roles: string[]) => {
+  try {
+    const response = await api.post("/admin/addrole", { nickname, roles });
+    console.log(response);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,5 @@
 //* 인증 관련 유틸 함수 관리
 import useAuthStore from "@/store/authStore";
-import { User } from "@/types/iadmin";
 import api from "@/utils/api";
 import { AxiosError, AxiosResponse } from "axios";
 
@@ -61,18 +60,6 @@ export const join = async ({
 export const logout = () => {
   useAuthStore.getState().logout();
   alert("로그아웃 완료");
-};
-
-// 회원 정보 all get 요청!
-export const getUserInfo = async (): Promise<User[]> => {
-  try {
-    const response = await api.get("/admin/userlist");
-    console.log("유저 정보", response);
-    return response.data;
-  } catch (error) {
-    console.error(error);
-    throw error;
-  }
 };
 
 // 현재 로그인한 회원 정보 get 요청!

--- a/src/app/(route)/admin/_component/roleSelect.tsx
+++ b/src/app/(route)/admin/_component/roleSelect.tsx
@@ -1,58 +1,69 @@
-// RoleSelect.tsx
-import React from "react";
+// 역할 변경 UI (Select, Checkbox, Save 버튼 등)을 재사용 가능한 컴포넌트로 모듈화
 import {
   Box,
-  Select,
-  MenuItem,
-  Chip,
-  SelectChangeEvent,
   Button,
+  Checkbox,
+  FormControl,
+  InputLabel,
+  ListItemText,
+  MenuItem,
+  Select,
 } from "@mui/material";
+import React from "react";
 
 interface RoleSelectProps {
-  username: string;
-  currentRoles: string[];
-  handleRoleChange: (
-    username: string
-  ) => (event: SelectChangeEvent<string[]>) => void;
-  handleApplyChanges: (username: string) => () => void;
+  nickname: string;
+  allRoles: string[];
+  selectedRoles: string[];
+  getRoleLabel: (role: string) => string;
+  onChange: (nickname: string, selected: string[]) => void;
+  onSave: (nickname: string) => void;
 }
 
 const RoleSelect: React.FC<RoleSelectProps> = ({
-  username,
-  currentRoles,
-  handleRoleChange,
-  handleApplyChanges,
+  nickname,
+  allRoles,
+  selectedRoles, //부모 compo에서 관리되는 상태 받아 초기, 현재 값들을 설정.
+  getRoleLabel,
+  onChange,
+  onSave,
 }) => {
+  // Select 박스에 현재 선택된 값을 렌더링하는 부분
+  const renderValue = (selected: string[]) => {
+    if (selected.length === 0)
+      return <em style={{ color: "grey" }}>역할 선택</em>;
+    // 선택된 역할이 3개 이상이라면 앞의 2개의 역할과 ...으로 요약 렌더링
+    if (selected.length > 2)
+      return `${selected.slice(0, 2).map(getRoleLabel).join(", ")}, ...`;
+    return selected.map(getRoleLabel).join(", ");
+  };
+
   return (
-    <Box display="flex" gap={1} alignItems="center" justifyContent="center">
-      <Select
-        multiple
-        value={currentRoles}
-        onChange={handleRoleChange(username)}
-        renderValue={(selected) => (
-          <Box display="flex" gap={1}>
-            {selected.map((value) => (
-              <Chip
-                key={value}
-                label={value.replace("ROLE_", "")}
-                size="small"
-              />
-            ))}
-          </Box>
-        )}
-        sx={{ minWidth: 150 }}
-      >
-        <MenuItem value="ROLE_ADMIN">ADMIN</MenuItem>
-        <MenuItem value="ROLE_USER">USER</MenuItem>
-        <MenuItem value="ROLE_ARTIST">ARTIST</MenuItem>
-      </Select>
-      <Button
-        variant="contained"
-        size="small"
-        onClick={handleApplyChanges(username)}
-      >
-        적용
+    <Box display="flex" alignItems="center">
+      <FormControl sx={{ m: 1, minWidth: 150 }}>
+        <InputLabel id={`select-label-${nickname}`}>역할 선택</InputLabel>
+        <Select
+          labelId={`select-label-${nickname}`}
+          id={`select-${nickname}`}
+          multiple
+          value={selectedRoles}
+          onChange={(e) => onChange(nickname, e.target.value as string[])}
+          renderValue={renderValue}
+          MenuProps={{ PaperProps: { style: { maxHeight: 200 } } }}
+        >
+          {allRoles.map((role) => {
+            const label = getRoleLabel(role);
+            return (
+              <MenuItem key={role} value={label}>
+                <Checkbox checked={selectedRoles.includes(label)} />
+                <ListItemText primary={label} />
+              </MenuItem>
+            );
+          })}
+        </Select>
+      </FormControl>
+      <Button onClick={() => onSave(nickname)} size="small" sx={{ ml: 1 }}>
+        저장
       </Button>
     </Box>
   );

--- a/src/app/(route)/admin/_component/userListTable.tsx
+++ b/src/app/(route)/admin/_component/userListTable.tsx
@@ -1,147 +1,193 @@
-// UserListTable.tsx
+// components/UserListTable.tsx
 "use client";
-import React, { useMemo, useState } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import {
-  useReactTable,
-  ColumnDef,
-  getCoreRowModel,
-  flexRender,
-} from "@tanstack/react-table";
-import {
+  CircularProgress,
   Table,
   TableBody,
+  TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  TableCell,
   Paper,
-  Typography,
 } from "@mui/material";
-import { SelectChangeEvent } from "@mui/material";
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  ColumnDef,
+} from "@tanstack/react-table";
+import { styled } from "@mui/material/styles";
+
+import { User } from "@/types/iadmin";
 import RoleSelect from "./roleSelect";
 
-interface User {
-  nickname: string;
-  username: string;
-  roles: string[];
-}
+// 테이블 셀 간격 조정을 위한 스타일
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  padding: theme.spacing(1, 3),
+}));
 
 interface UserListTableProps {
   users: User[];
-  onUpdateUserRoles?: (username: string, roles: string[]) => void;
+  allRoles: string[];
+  onSaveRoles: (nickname: string, roles: string[]) => Promise<void>;
+  loading: boolean;
+  error: Error | null;
+  getRoleLabel: (role: string) => string;
 }
 
 const UserListTable: React.FC<UserListTableProps> = ({
   users,
-  onUpdateUserRoles,
+  allRoles,
+  onSaveRoles,
+  loading,
+  error,
+  getRoleLabel,
 }) => {
-  const data = useMemo(() => users, [users]);
-  const [editedRoles, setEditedRoles] = useState<{
-    [username: string]: string[];
+  const [selectedRolesInternal, setSelectedRolesInternal] = useState<{
+    [nickname: string]: string[];
   }>({});
 
-  const handleRoleChange =
-    (username: string) => (event: SelectChangeEvent<string[]>) => {
-      const selectedRoles = event.target.value as string[];
-      setEditedRoles((prev) => ({ ...prev, [username]: selectedRoles }));
-    };
+  // 역할 드롭다운 값 변경 시 호출 콜백함수.
+  const handleRoleChangeInternal = useCallback(
+    (nickname: string, newRolesWithoutPrefix: string[]) => {
+      // 접두사에 ROLE_ 붙여서 저장.
+      const newRolesWithPrefix = newRolesWithoutPrefix.map(
+        (role) => `ROLE_${role}`
+      );
+      // 임시 선택 역할 상태 업데이트
+      setSelectedRolesInternal((prev) => ({
+        ...prev,
+        [nickname]: newRolesWithPrefix,
+      }));
+    },
+    [setSelectedRolesInternal]
+  );
 
-  const handleApplyChanges = (username: string) => () => {
-    if (onUpdateUserRoles) {
-      onUpdateUserRoles(username, editedRoles[username] || []);
-    }
-  };
+  // 저장 버튼 클릭 시 호출 콜백 함수
+  const handleSaveRolesInternal = useCallback(
+    async (nickname: string) => {
+      // 임시 선택 역할 상태에 있는 사용자의 역할 목록 업데인트
+      const rolesToUpdate = selectedRolesInternal[nickname] || [];
+      // 저장 완료 시 선택 역할 상태에서 해당 사용자 정보 제거
+      await onSaveRoles(nickname, rolesToUpdate);
+      setSelectedRolesInternal((prev) => {
+        const newState = { ...prev };
+        delete newState[nickname];
+        return newState;
+      });
+    },
+    [selectedRolesInternal, onSaveRoles]
+  );
 
+  // tanstack table 컬럼 정의
   const columns = useMemo<ColumnDef<User>[]>(
     () => [
       {
-        header: "닉네임",
+        header: "닉네임", // 테이블 헤더 텍스트
         accessorKey: "nickname",
-        cell: ({ getValue }) => (
-          <Typography variant="body2" fontWeight="bold">
-            {getValue() as string}
-          </Typography>
-        ),
       },
       {
-        header: "유저명",
+        header: "이메일",
         accessorKey: "username",
-        cell: ({ getValue }) => (
-          <Typography variant="body2" color="text.secondary">
-            {getValue() as string}
-          </Typography>
-        ),
       },
       {
-        header: "권한",
-        accessorKey: "roles",
+        header: "현재 역할",
+        // user 객체에서 roles배열 가져온 후 UI 레이블로 변환 하고 쉼표로 연결하기.
+        accessorFn: (row) => row.roles?.map(getRoleLabel).join(", ") || "없음",
+        id: "currentRoles",
+      },
+      {
+        header: "역할 변경",
+        id: "editRoles",
+        // 각 셀 내용 렌더링 부분.
         cell: ({ row }) => {
-          const username = row.original.username;
-          const currentRoles =
-            editedRoles[username] || row.original.roles || [];
+          const nickname = row.original.nickname;
+          // 현재 유저가 임시 선택한 역할 목록 or 현재 역할 목록
+          const currentUserSelectedRolesWithPrefix =
+            selectedRolesInternal[nickname] || row.original.roles || [];
+          // ROLE_ 제거하고 UI에 표시할 역할 목록 생성.
+          const currentUserSelectedRolesWithoutPrefix =
+            currentUserSelectedRolesWithPrefix.map((role) =>
+              getRoleLabel(role)
+            );
+
           return (
+            // 역할 선택 UI 컴포넌트.
             <RoleSelect
-              username={username}
-              currentRoles={currentRoles}
-              handleRoleChange={handleRoleChange}
-              handleApplyChanges={handleApplyChanges}
+              nickname={nickname}
+              allRoles={allRoles}
+              selectedRoles={currentUserSelectedRolesWithoutPrefix}
+              getRoleLabel={getRoleLabel}
+              onChange={handleRoleChangeInternal}
+              onSave={handleSaveRolesInternal}
             />
           );
         },
       },
     ],
-    [editedRoles]
+    [
+      allRoles,
+      selectedRolesInternal,
+      handleRoleChangeInternal,
+      handleSaveRolesInternal,
+      getRoleLabel,
+    ]
   );
 
+  // Table 인스턴스 생성
   const table = useReactTable({
-    data,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
+    data: users, // 테이블 데이터 (부모 컴포에서 props로 전달)
+    columns, // 테이블 컬럼 정의
+    getCoreRowModel: getCoreRowModel(), // 기본 행 모델 생성 함수
   });
 
+  if (loading) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
   return (
-    <TableContainer
-      component={Paper}
-      sx={{ mt: 2, p: 2, borderRadius: 2, boxShadow: 2 }}
-    >
-      <Table>
-        <TableHead sx={{ backgroundColor: "#f5f5f5" }}>
+    <TableContainer component={Paper}>
+      <Table aria-label="user list table">
+        <TableHead>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableCell
-                  key={header.id}
-                  sx={{ fontWeight: "bold", textAlign: "center" }}
-                >
+                <StyledTableCell key={header.id}>
                   {flexRender(
                     header.column.columnDef.header,
                     header.getContext()
                   )}
-                </TableCell>
+                </StyledTableCell>
               ))}
             </TableRow>
           ))}
         </TableHead>
         <TableBody>
-          {table.getRowModel().rows.length > 0 ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id} hover>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} sx={{ textAlign: "center" }}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={3} sx={{ textAlign: "center", py: 3 }}>
-                <Typography variant="body2" color="text.secondary">
-                  유저 데이터가 없습니다.
-                </Typography>
-              </TableCell>
+          {table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <StyledTableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </StyledTableCell>
+              ))}
             </TableRow>
-          )}
+          ))}
         </TableBody>
       </Table>
     </TableContainer>

--- a/src/app/(route)/admin/page.tsx
+++ b/src/app/(route)/admin/page.tsx
@@ -1,76 +1,94 @@
 "use client";
-import { getUserInfo } from "@/api/auth";
-import React, { useState, useEffect } from "react";
-import UserListTable from "./_component/userListTable";
-import { CircularProgress } from "@mui/material";
-import { User } from "@/types/iadmin";
-import useAuthStore, { getUserRoles } from "@/store/authStore";
+import React, { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+
+import { User } from "@/types/iadmin";
+import { getUserInfo, postAddRole } from "@/api/admin";
+import useAuthStore, { getUserRoles } from "@/store/authStore";
+import UserListTable from "./_component/userListTable";
 
 const AdminUserListPage: React.FC = () => {
   const [userList, setUserList] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  // 관리자 권한 상태
   const [authChecked, setAuthChecked] = useState(false);
+  // 전역 상태에서 역할 정보 가져오기
   const { roles } = useAuthStore();
   const router = useRouter();
+  const [allRoles, setAllRoles] = useState<string[]>([]);
+
+  const getRoleLabel = useCallback((role: string) => {
+    return role.replace(/^ROLE_/, "");
+  }, []);
 
   useEffect(() => {
     const checkAdminRole = () => {
+      // 로컬 스토리지에서 역할 정보를 가져오거나, Zustand 스토어의 현재 역할 정보를 사용
       const storedRoles = getUserRoles() || roles;
-
+      // 관리자 역할이 없으면 메인 페이지로 리다이렉트
       if (!storedRoles || !storedRoles.includes("ROLE_ADMIN")) {
         router.push("/");
         return;
       }
+      // 관리자 역할이 확인되면 authChecked 상태를 true로 설정
       setAuthChecked(true);
     };
-
     checkAdminRole();
   }, [roles, router]);
 
   useEffect(() => {
     if (authChecked) {
-      const fetchUserList = async () => {
+      const fetchAdminData = async () => {
+        setLoading(true);
+        setError(null);
         try {
-          const data = await getUserInfo();
-          setUserList(data);
+          const usersData = await getUserInfo();
+          setUserList(usersData);
+          //! 모든 가능한 역할 목록 설정--> 이 부분 수정 사항에 포함해야할듯.
+          setAllRoles(["ROLE_USER", "ROLE_ADMIN", "ROLE_ARTIST"]);
         } catch (err) {
           setError(err instanceof Error ? err : new Error(String(err)));
         } finally {
           setLoading(false);
         }
       };
-
-      fetchUserList();
+      fetchAdminData();
     }
   }, [authChecked]);
 
-  if (!authChecked || loading) {
-    return (
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          height: "100vh",
-        }}
-      >
-        <CircularProgress />
-      </div>
-    );
+  // 사용자 역할 변경 후 저장 버튼 클릭 시 호출되는 비동기 콜백 함수
+  const handleSaveRoles = useCallback(
+    async (nickname: string, rolesToUpdate: string[]) => {
+      try {
+        // 서버에 변경된 역할 정보 전송
+        await postAddRole(nickname, rolesToUpdate);
+        console.log(`역할이 성공적으로 업데이트되었습니다: ${nickname}`);
+        // 역할 업데이트 후 최신 사용자 정보 다시 가져오기
+        const data = await getUserInfo();
+        setUserList(data);
+      } catch (error) {
+        console.error(`역할 업데이트 실패: ${nickname}`, error);
+      }
+    },
+    [setUserList]
+  );
+
+  if (!authChecked) {
+    return null;
   }
 
-  if (error) return <div>Error: {error.message}</div>;
-
   return (
-    <div
-      style={{
-        height: "100vh",
-      }}
-    >
+    <div style={{ height: "100vh", padding: 16 }}>
       <h1>전체 사용자 목록</h1>
-      <UserListTable users={userList} />
+      <UserListTable
+        users={userList} // 사용자 목록
+        allRoles={allRoles} // 모든 역할 목록
+        onSaveRoles={handleSaveRoles} // 역할 저장 함수
+        loading={loading}
+        error={error}
+        getRoleLabel={getRoleLabel} // 역할 레이블 변환
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 어떤 기능인가요?

> 권한 부여 API 연동 및 UI 수정, 추후 기능 고려 사항

## 작업 상세 내용

- [x] 권한은 배열 형식이므로 한 명의 유저가 2개 이상의 권한 보유 가능<유의>
(실제 서비스의 측면에서 생각해봤을 때는 굳이? 의미가 있나 싶긴 함)
(어느 부분에서 실질적으로 사용성이 있을 지 고민해봐도 좋을 듯)

- [x] 추후 기능적인 측면에서 확장 가능성 고려한 작업
1. 탈퇴 기능, 정지 기능 등등 (★★★★☆)
2. 특정 유저가 구매한 상품 목록 조회(★☆☆☆☆)
3. 댓글 작성 시 신고 당한 계정 등등.. (★★★☆☆) 
4. 계정 검색 및 카테고리 별 조회(ex 권한에 따라 모아보기 계정) (★★★★★)
5. 게시된 상품 관리 (★☆☆☆☆)
위 사항들이 추후 기능 고려 대상들

- [x] 직관적인 UI로 변경 
- [ ] 추후 유저가 많아지면 많아질 수록 페이지네이션 적용 필수


Close #65 