### PR TITLE
앨범 페이지 UI 수정 및 리프레시 토큰 바디 설정

### DIFF
--- a/src/app/(route)/artist/(tabs)/albumTab.tsx
+++ b/src/app/(route)/artist/(tabs)/albumTab.tsx
@@ -50,8 +50,7 @@ function AlbumTab() {
                   alt={album.title}
                   width={200}
                   height={200}
-                  objectFit="contain"
-                  style={{ borderRadius: "8px" }}
+                  style={{ borderRadius: "8px", objectFit: "contain" }}
                 />
                 <Typography variant="body2" fontWeight={600} mt={2}>
                   {album.title}

--- a/src/app/(route)/discography/_components/albumDetail.tsx
+++ b/src/app/(route)/discography/_components/albumDetail.tsx
@@ -46,19 +46,24 @@ function AlbumDetail({ album }: AlbumDetailProps) {
         <Box sx={{ ml: 10 }}>
           <Typography variant="h6">TITLE</Typography>
           <Box display={"flex"} flexDirection={"row"} alignItems={"center"}>
-            <Typography variant="subtitle1">{album.title}, </Typography>
-            <Typography variant="subtitle2">{album.description}</Typography>
+            <Typography variant="subtitle1" color="#797979">
+              {album.title}
+            </Typography>
           </Box>
 
           <Typography variant="h6" sx={{ mt: 3 }}>
             INTRO
           </Typography>
-          <Typography variant="subtitle2">{album.description}</Typography>
+          <Typography variant="subtitle2" color="#797979">
+            {album.description}
+          </Typography>
 
           <Typography variant="h6" sx={{ mt: 3 }}>
             DATE
           </Typography>
-          <Typography variant="subtitle2">{album.releaseDate}</Typography>
+          <Typography variant="subtitle2" color="#797979">
+            {album.releaseDate}
+          </Typography>
 
           <Typography variant="h6" sx={{ mt: 3 }}>
             트랙 목록

--- a/src/app/(route)/discography/_components/albumLists.tsx
+++ b/src/app/(route)/discography/_components/albumLists.tsx
@@ -3,7 +3,7 @@
 // 앨범 썸네일, 제목, 카테고리 정보 표시
 // 페이지 네이션, 카테고리 필터링 예정 (검색은 미예정)
 // 앨범 클릭시 상위 컴포넌트의 albumclick 함수 호출하기
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Image from "next/image";
 import { AlbumInfo } from "@/types/idiscography";
 import { Box, Container, IconButton, Typography } from "@mui/material";
@@ -41,9 +41,9 @@ function AlbumLists({ albums, category, onAlbumClick }: AlbumListsProps) {
   };
 
   // 태그 변경할때마다 페이지 초기화
-  useEffect(() => {
-    setPage(0);
-  }, [category]);
+  // useEffect(() => {
+  //   setPage(0);
+  // }, [category]);
 
   // 마우스 hover시 효과
   const [hoveredAlbumId, setHoveredAlbumId] = useState<number | null>(null);
@@ -87,7 +87,7 @@ function AlbumLists({ albums, category, onAlbumClick }: AlbumListsProps) {
                 width: "340px",
                 height: "340px",
                 position: "relative",
-                backgroundColor: "#414141",
+                backgroundColor: "#f7ecec",
                 zIndex: 1,
                 borderRadius: "8px",
                 display: "flex",

--- a/src/app/(route)/discography/page.tsx
+++ b/src/app/(route)/discography/page.tsx
@@ -5,13 +5,13 @@
 // 하위 컴포넌트에 각각에 필요한 데이터 전달.
 
 import { Box, Tab, Tabs, Typography } from "@mui/material";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import AlbumLists from "./_components/albumLists";
 import { AlbumDetailInfo, AlbumInfo } from "@/types/idiscography";
 import AlbumDetail from "./_components/albumDetail";
 import { getAlbumDetail, getAlbumList } from "@/api/discography";
 
-const categories = ["All", "Regular", "Single", "Mini", "Ost", "Others"];
+const categories = ["All", "Regular", "Single", "Mini", "OST", "Others"];
 
 function Discography() {
   const [albums, setAlbums] = useState<AlbumInfo[] | null>(null);
@@ -23,17 +23,23 @@ function Discography() {
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  // ref 생성 --> DOM 노드에 접근
+  const albumDetailRef = useRef<HTMLDivElement>(null);
 
   // 앨범 리스트 GET 요청!
   useEffect(() => {
     async function fetchData() {
-      setLoading(true);
+      // setLoading(true);
       try {
         const albumListData = await getAlbumList(); // 초기 페이지 데이터 가져오기
         setAlbums(albumListData);
 
+        //* 초기 로딩 || 카테고리 변경 후 첫 번째 앨범 선택
         if (albumListData && albumListData.length > 0) {
-          setSelectedAlbumId(albumListData[albumListData.length - 1].id); // 가장 마지막 앨범 ID 설정
+          setSelectedAlbumId(albumListData[0].id);
+        } else {
+          setSelectedAlbumId(null);
+          setSelectedAlbum(null);
         }
       } catch (err) {
         setError(
@@ -41,6 +47,7 @@ function Discography() {
             ? err
             : new Error("데이터를 불러오는 중 오류가 발생했습니다.")
         );
+        setAlbums(null);
       } finally {
         setLoading(false);
       }
@@ -49,13 +56,23 @@ function Discography() {
     fetchData();
   }, [category]);
 
-  const handleAlbumClick = (id: number) => {
-    console.log(`Album ${id} clicked`);
-    setSelectedAlbumId(id);
-  };
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabValue(newValue);
     setCategory(categories[newValue]);
+  };
+
+  const handleAlbumClick = (id: number) => {
+    console.log(`Album ${id} clicked`);
+    setSelectedAlbumId(id);
+    // 상세 정보 렌더링 후 스크롤 실행
+    setTimeout(() => {
+      if (albumDetailRef.current) {
+        albumDetailRef.current.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }
+    }, 100);
   };
 
   // 앨범 디테일 GET 요청!
@@ -71,7 +88,10 @@ function Discography() {
               ? err
               : new Error("앨범 상세 정보를 불러오는 중 오류가 발생했습니다.")
           );
+          setSelectedAlbum(null);
         }
+      } else {
+        setSelectedAlbum(null);
       }
     }
 
@@ -94,14 +114,32 @@ function Discography() {
           DISCOGRAPHY
         </Typography>
       </Box>
-      <Box display="flex" flexDirection="column" alignItems="center">
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        ref={albumDetailRef}
+      >
         {selectedAlbum && <AlbumDetail album={selectedAlbum} />}
+        {!selectedAlbum && <Typography>앨범을 선택해주세요. </Typography>}
       </Box>
       <Tabs
         value={tabValue}
         onChange={handleTabChange}
         aria-label="album category tabs"
-        sx={{ mt: 6 }}
+        sx={{
+          mt: 6,
+          "& .MuiTabs-indicator": {
+            backgroundColor: "#FCC422",
+          },
+          "& .MuiTab-root": {
+            color: "gray",
+            "&.Mui-selected": {
+              color: "#FCC422",
+              fontWeight: "bold",
+            },
+          },
+        }}
       >
         {categories.map((categorie, index) => (
           <Tab key={index} label={categorie} />

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -34,11 +34,12 @@ api.interceptors.response.use(
       if (error.response.status === 401 && !originalRequest._retry) {
         originalRequest._retry = true; // 무한 루프 방지
         const username = getUserName();
+        const token = getAccessToken();
 
         try {
           const { data } = await axios.post(
             `${API_BASED_URL}/refresh`,
-            { username },
+            { username, token },
             { withCredentials: true }
           );
 


### PR DESCRIPTION
## 어떤 기능인가요?

> 앨범 페이지 UI 수정 및 리프레시 토큰 바디 설정

## 작업 상세 내용

- [ ] 앨범 페이지 탭 클릭 시 리프레시 되는 현상 해결 --> 현재 로딩 컴포넌트가 없어서 loading 텍스트 때문에 한번 페이지가 렌더링 됐다가 --> 넘어가고 있어서 리프레시 되는 느낌 발생
- [ ] 해당 앨범 클릭시 디테일 렌더링 후 자연스럽게 위로 스크롤되는 훅 사용
- [ ] useRef 연결해서 상세 정보 표시하는 컴포넌트에 DOM 요소 연결(prop할당), timeout 걸어서 자연스럽게 올라가도록 설정

Close #72 