### PR TITLE
프로필 페이지 기능 리팩토링 (refac/#81)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^6.4.8",
         "@mui/material": "^6.4.8",
         "@mui/material-nextjs": "^6.4.3",
+        "@tanstack/react-query": "^5.74.3",
         "@tanstack/react-table": "^8.21.2",
         "axios": "^1.8.4",
         "framer-motion": "^12.6.2",
@@ -1398,6 +1399,30 @@
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.74.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.3.tgz",
+      "integrity": "sha512-Mqk+5o3qTuAiZML248XpNH8r2cOzl15+LTbUsZQEwvSvn1GU4VQhvqzAbil36p+MBxpr/58oBSnRzhrBevDhfg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.74.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.3.tgz",
+      "integrity": "sha512-QrycUn0wxjVPzITvQvOxFRdhlAwIoOQSuav7qWD4SWCoKCdLbyRZ2vji2GuBq/glaxbF4wBx3fqcYRDOt8KDTA==",
+      "dependencies": {
+        "@tanstack/query-core": "5.74.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^6.4.8",
     "@mui/material": "^6.4.8",
     "@mui/material-nextjs": "^6.4.3",
+    "@tanstack/react-query": "^5.74.3",
     "@tanstack/react-table": "^8.21.2",
     "axios": "^1.8.4",
     "framer-motion": "^12.6.2",

--- a/src/app/(route)/artist/(artistProfile)/profileHeader.tsx
+++ b/src/app/(route)/artist/(artistProfile)/profileHeader.tsx
@@ -1,5 +1,6 @@
+import FadeInUpWrapper from "@/components/commonAnimation/FadeInUpWrapper";
 import { Box, Typography } from "@mui/material";
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import Image from "next/image";
 
 const ProfileHeader = () => {
@@ -15,11 +16,7 @@ const ProfileHeader = () => {
         />
       </Box>
       <AnimatePresence>
-        <motion.div
-          initial={{ opacity: 0, y: 50 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
+        <FadeInUpWrapper>
           <Box mt={10} textAlign="center">
             <Typography variant="h3" fontWeight={600}>
               Profile
@@ -39,7 +36,7 @@ const ProfileHeader = () => {
               </Typography>
             </Box>
           </Box>
-        </motion.div>
+        </FadeInUpWrapper>
       </AnimatePresence>
     </>
   );

--- a/src/app/(route)/artist/(artistProfile)/profileInfo.tsx
+++ b/src/app/(route)/artist/(artistProfile)/profileInfo.tsx
@@ -1,14 +1,17 @@
+import FadeInUpWrapper from "@/components/commonAnimation/FadeInUpWrapper";
 import { Box, Typography } from "@mui/material";
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
+
+const debutDates = [
+  "2018 10/29 IZ*ONE",
+  "2021 10/07 (솔로)",
+  "2022 07/22 (배우)",
+];
 
 const ProfileInfo = () => {
   return (
     <AnimatePresence>
-      <motion.div
-        initial={{ opacity: 0, y: 50 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5 }}
-      >
+      <FadeInUpWrapper>
         <Box
           display="flex"
           justifyContent="space-evenly"
@@ -26,9 +29,11 @@ const ProfileInfo = () => {
               </Typography>
             </Box>
             <Box mt={1} mr={2}>
-              <Typography variant="body2">2018 10/29 IZ*ONE</Typography>
-              <Typography variant="body2">2021 10/07 (솔로) </Typography>
-              <Typography variant="body2">2022 07/22 (배우)</Typography>
+              {debutDates.map((date, idx) => (
+                <Typography key={idx} variant="body2">
+                  {date}
+                </Typography>
+              ))}
             </Box>
           </Box>
           <Box display="flex">
@@ -42,7 +47,7 @@ const ProfileInfo = () => {
             </Box>
           </Box>
         </Box>
-      </motion.div>
+      </FadeInUpWrapper>
     </AnimatePresence>
   );
 };

--- a/src/app/(route)/artist/(tabs)/albumTab.tsx
+++ b/src/app/(route)/artist/(tabs)/albumTab.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import RetryErrorBox from "@/components/commonProfileTab/refetchButton";
+import LoadingIndicator from "@/components/LoadingIndicator";
 import useFetchAlbums from "@/hooks/useProfileTabApi/useFetchAlbum";
-import { Box, CircularProgress, Typography, Button } from "@mui/material";
+import { Box, Typography, Button } from "@mui/material";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
 import { useState } from "react";
@@ -9,36 +11,24 @@ import { useState } from "react";
 const ITEMS_PER_PAGE = 6;
 
 function AlbumTab() {
-  const { albumsData, loading, error } = useFetchAlbums();
+  const { data: albumsData, loading, error, refetch } = useFetchAlbums();
+  // const { albumsData, loading, error } = useFetchAlbums();
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
+  // null 체크 (초기 로딩 이후에도 data가 없을 수 있으니까)
+  if (!albumsData) return null;
   const visibleAlbums = albumsData.slice(0, visibleCount);
   const hasMore = visibleCount < albumsData.length;
 
   if (loading) {
-    return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight={200}
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingIndicator message="앨범 정보를 불러오는 중입니다..." />;
   }
 
   if (error) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight={200}
-      >
-        <Typography color="error">
-          앨범 정보를 불러오는 중 오류가 발생했습니다: {error.message}
-        </Typography>
-      </Box>
+      <RetryErrorBox
+        message="앨범 정보를 불러오는 중 오류가 발생했습니다"
+        onRetry={refetch}
+      />
     );
   }
 

--- a/src/app/(route)/artist/(tabs)/albumTab.tsx
+++ b/src/app/(route)/artist/(tabs)/albumTab.tsx
@@ -1,83 +1,145 @@
-import { getAlbumList } from "@/api/discography";
-import { Album } from "@/types/iprofile";
-import { Box, Typography } from "@mui/material";
+"use client";
+
+import useFetchAlbums from "@/hooks/useProfileTabApi/useFetchAlbum";
+import { Box, CircularProgress, Typography, Button } from "@mui/material";
 import { motion, AnimatePresence } from "framer-motion";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-import { useInView } from "react-intersection-observer";
+import { useState } from "react";
+
+const ITEMS_PER_PAGE = 6;
 
 function AlbumTab() {
-  const [albums, setAlbums] = useState<Album[]>([]);
-  //마운트시 getAlbumLList 실행 후 목록 저장.
-  const [ref, inView] = useInView({
-    triggerOnce: true,
-    rootMargin: "-50px 0px",
-  });
+  const { albumsData, loading, error } = useFetchAlbums();
+  const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
+  const visibleAlbums = albumsData.slice(0, visibleCount);
+  const hasMore = visibleCount < albumsData.length;
 
-  useEffect(() => {
-    if (inView) {
-      const fetchAlbumList = async () => {
-        const albumList = await getAlbumList();
-        setAlbums(albumList);
-        console.log(albumList);
-      };
-      fetchAlbumList();
-    }
-  }, [inView]);
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight={200}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight={200}
+      >
+        <Typography color="error">
+          앨범 정보를 불러오는 중 오류가 발생했습니다: {error.message}
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
-    <Box display="flex" flexDirection="column" alignItems="center" ref={ref}>
-      <AnimatePresence>
-        {inView &&
-          albums.map((album) => (
+    <Box display="flex" flexDirection="column" alignItems="center">
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "center",
+          gap: 2,
+          maxWidth: "800px",
+        }}
+      >
+        <AnimatePresence>
+          {visibleAlbums.map((album) => (
             <motion.div
               key={album.id}
-              initial={{ opacity: 0, y: 50 }}
+              initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.4, ease: "easeOut" }}
+              style={{
+                width: "calc(33.333% - 20px)",
+                minWidth: "200px",
+                display: "flex",
+                alignItems: "center",
+              }}
             >
               <Box
-                key={album.id}
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  marginTop: 4,
-                }}
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                p={2}
+                borderRadius={2}
+                bgcolor="#fafafa"
               >
                 <Image
                   src={`/api${album.albumImages[0]?.url}`}
                   alt={album.title}
                   width={200}
                   height={200}
-                  style={{ borderRadius: "8px", objectFit: "contain" }}
+                  style={{ borderRadius: 8, objectFit: "cover" }}
                 />
-                <Typography variant="body2" fontWeight={600} mt={2}>
+                <Typography
+                  variant="body2"
+                  fontWeight={600}
+                  mt={2}
+                  textAlign="center"
+                >
                   {album.title}
                 </Typography>
-                <Typography variant="body2" fontWeight={400} mt={2}>
+                <Typography
+                  variant="body2"
+                  fontWeight={400}
+                  mt={1}
+                  textAlign="center"
+                >
                   {album.description}
                 </Typography>
-                <Typography style={{ fontSize: "0.7rem", color: "#9c9c9c" }}>
+                <Typography
+                  sx={{
+                    fontSize: "0.75rem",
+                    color: "#9c9c9c",
+                    mt: 1,
+                    textAlign: "center",
+                  }}
+                >
                   {album.releaseDate}
                 </Typography>
               </Box>
             </motion.div>
           ))}
-      </AnimatePresence>
-      <Box sx={{ marginTop: "100px" }}>
-        <iframe
-          style={{ borderRadius: "12px" }}
-          src="https://open.spotify.com/embed/playlist/3f9oODTECIUKiQweioS0mS?utm_source=generator&theme=0"
-          width="300"
-          height="380"
-          allowFullScreen
-          allow="encrypted-media"
-          loading="lazy"
-        />
+        </AnimatePresence>
       </Box>
+
+      {hasMore && (
+        <Button
+          variant="outlined"
+          onClick={() => setVisibleCount((prev) => prev + ITEMS_PER_PAGE)}
+          sx={{ mt: 4, mb: 6, fontWeight: 600 }}
+        >
+          더 보기
+        </Button>
+      )}
     </Box>
   );
 }
 
 export default AlbumTab;
+
+{
+  /* <Box sx={{ marginTop: "80px", display: "flex", justifyContent: "center" }}>
+  <iframe
+    style={{ borderRadius: "12px" }}
+    src="https://open.spotify.com/embed/playlist/3f9oODTECIUKiQweioS0mS?utm_source=generator&theme=0"
+    width="300"
+    height="380"
+    allowFullScreen
+    allow="encrypted-media"
+    loading="lazy"
+  />
+</Box>; */
+}

--- a/src/app/(route)/artist/(tabs)/albumTab.tsx
+++ b/src/app/(route)/artist/(tabs)/albumTab.tsx
@@ -14,10 +14,6 @@ function AlbumTab() {
   const { data: albumsData, loading, error, refetch } = useFetchAlbums();
   // const { albumsData, loading, error } = useFetchAlbums();
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
-  // null 체크 (초기 로딩 이후에도 data가 없을 수 있으니까)
-  if (!albumsData) return null;
-  const visibleAlbums = albumsData.slice(0, visibleCount);
-  const hasMore = visibleCount < albumsData.length;
 
   if (loading) {
     return <LoadingIndicator message="앨범 정보를 불러오는 중입니다..." />;
@@ -31,6 +27,11 @@ function AlbumTab() {
       />
     );
   }
+
+  // null 체크 (초기 로딩 이후에도 data가 없을 수 있으니까)
+  if (!albumsData) return null;
+  const visibleAlbums = albumsData.slice(0, visibleCount);
+  const hasMore = visibleCount < albumsData.length;
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center">

--- a/src/app/(route)/artist/(tabs)/albumTab.tsx
+++ b/src/app/(route)/artist/(tabs)/albumTab.tsx
@@ -2,7 +2,6 @@
 
 import AlbumSkeleton from "@/components/commonProfileTab/AlbumSkeleton";
 import RetryErrorBox from "@/components/commonProfileTab/refetchButton";
-// import LoadingIndicator from "@/components/LoadingIndicator";
 import useFetchAlbums from "@/hooks/useProfileTabApi/useFetchAlbum";
 import { Box, Typography, Button } from "@mui/material";
 import { motion, AnimatePresence } from "framer-motion";
@@ -10,24 +9,18 @@ import Image from "next/image";
 import { useState } from "react";
 
 const ITEMS_PER_PAGE = 6;
-// 최소 로딩 시간 0.5초
 const MIN_LOADING_TIME = 500;
 
 function AlbumTab() {
-  // const { albumsData, loading, error } = useFetchAlbums();
-  // const { data: albumsData, loading, error, refetch } = useFetchAlbums();
   const {
     data: albumsData,
-    loading,
-    error,
+    isLoading,
+    isError,
     refetch,
   } = useFetchAlbums(MIN_LOADING_TIME);
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
 
-  // if (loading) {
-  //   return <LoadingIndicator message="앨범 정보를 불러오는 중입니다..." />;
-  // }
-  if (loading) {
+  if (isLoading) {
     return (
       <Box display="flex" flexDirection="column" alignItems="center">
         <AlbumSkeleton /> {/* 로딩 중에는 스켈레톤 UI 표시 */}
@@ -38,7 +31,7 @@ function AlbumTab() {
     );
   }
 
-  if (error) {
+  if (isError) {
     return (
       <RetryErrorBox
         message="앨범 정보를 불러오는 중 오류가 발생했습니다"

--- a/src/app/(route)/artist/(tabs)/albumTab.tsx
+++ b/src/app/(route)/artist/(tabs)/albumTab.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import AlbumSkeleton from "@/components/commonProfileTab/AlbumSkeleton";
 import RetryErrorBox from "@/components/commonProfileTab/refetchButton";
-import LoadingIndicator from "@/components/LoadingIndicator";
+// import LoadingIndicator from "@/components/LoadingIndicator";
 import useFetchAlbums from "@/hooks/useProfileTabApi/useFetchAlbum";
 import { Box, Typography, Button } from "@mui/material";
 import { motion, AnimatePresence } from "framer-motion";
@@ -9,14 +10,32 @@ import Image from "next/image";
 import { useState } from "react";
 
 const ITEMS_PER_PAGE = 6;
+// 최소 로딩 시간 0.5초
+const MIN_LOADING_TIME = 500;
 
 function AlbumTab() {
-  const { data: albumsData, loading, error, refetch } = useFetchAlbums();
   // const { albumsData, loading, error } = useFetchAlbums();
+  // const { data: albumsData, loading, error, refetch } = useFetchAlbums();
+  const {
+    data: albumsData,
+    loading,
+    error,
+    refetch,
+  } = useFetchAlbums(MIN_LOADING_TIME);
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_PAGE);
 
+  // if (loading) {
+  //   return <LoadingIndicator message="앨범 정보를 불러오는 중입니다..." />;
+  // }
   if (loading) {
-    return <LoadingIndicator message="앨범 정보를 불러오는 중입니다..." />;
+    return (
+      <Box display="flex" flexDirection="column" alignItems="center">
+        <AlbumSkeleton /> {/* 로딩 중에는 스켈레톤 UI 표시 */}
+        <Typography variant="body2" color="textSecondary" mt={2}>
+          앨범 정보를 불러오는 중입니다...
+        </Typography>
+      </Box>
+    );
   }
 
   if (error) {

--- a/src/app/(route)/artist/(tabs)/awardsTab.tsx
+++ b/src/app/(route)/artist/(tabs)/awardsTab.tsx
@@ -1,58 +1,25 @@
-import { Box, Typography } from "@mui/material";
+import AwardItem from "@/components/commonProfileTab/AwardItem";
+import { awardsData } from "@/constants/awardsData";
+import { Box, Divider, Typography } from "@mui/material";
 
 function AwardsTab() {
   return (
-    <Box>
-      <Box display="flex" flexDirection="column" gap={1}>
-        <Box display="flex" gap={2}>
-          <Typography variant="body2" fontWeight={500}>
-            2025
+    <Box display="flex" flexDirection="column" alignItems="center" mt={2}>
+      {awardsData.map(({ year, awards }, index) => (
+        <Box key={year} width="100%" maxWidth="600px" mb={4}>
+          <Typography variant="subtitle1" fontWeight={600} mb={1}>
+            {year}
           </Typography>
-          <Typography variant="body2" fontWeight={300}>
-            제1회 디 어워즈 (D Awards) - 임팩트상 수상
-          </Typography>
+          <Box component="ul" sx={{ pl: 3, m: 0 }}>
+            {awards.map((award, idx) => (
+              <AwardItem key={idx} text={award} />
+            ))}
+          </Box>
+          {index < awardsData.length - 1 && (
+            <Divider sx={{ mt: 3, borderColor: "rgba(0,0,0,0.1)" }} />
+          )}
         </Box>
-        <Box display="flex" gap={2}>
-          <Typography variant="body2" fontWeight={500}>
-            2024
-          </Typography>
-          <Typography variant="body2" fontWeight={300}>
-            2024 아시아 아티스트 어워즈 (AAA 2024) AAA 베스트 초이스상 수상
-          </Typography>
-        </Box>
-        <Box display="flex" gap={2}>
-          <Typography variant="body2" fontWeight={500}>
-            2024
-          </Typography>
-          <Typography variant="body2" fontWeight={300}>
-            2024 아시아 아티스트 어워즈 (AAA 2024)​ AAA 이모티브상 수상
-          </Typography>
-        </Box>
-        <Box display="flex" gap={2}>
-          <Typography variant="body2" fontWeight={500}>
-            2023
-          </Typography>
-          <Typography variant="body2" fontWeight={300}>
-            2023 대한민국 퍼스트브랜드 대상
-          </Typography>
-        </Box>
-        <Box display="flex" gap={2}>
-          <Typography variant="body2" fontWeight={500}>
-            2022
-          </Typography>
-          <Typography variant="body2" fontWeight={300}>
-            MNET JAPAN FAN’S CHOICE AWARDS
-          </Typography>
-        </Box>
-        <Box display="flex" gap={2}>
-          <Typography variant="body2" fontWeight={500}>
-            2022
-          </Typography>
-          <Typography variant="body2" fontWeight={300}>
-            SBS MTV 더쇼 1위 수상
-          </Typography>
-        </Box>
-      </Box>
+      ))}
     </Box>
   );
 }

--- a/src/app/(route)/artist/(tabs)/concertTabs.tsx
+++ b/src/app/(route)/artist/(tabs)/concertTabs.tsx
@@ -1,39 +1,27 @@
 import useFetchConcerts from "@/hooks/useProfileTabApi/useFetchConcerts";
-import { Box, CircularProgress, Divider, Typography } from "@mui/material";
+import { Box, Divider, Typography } from "@mui/material";
 import groupConcertsByYear from "@/utils/groupConcertsByYear";
 import ConcertItem from "@/components/commonProfileTab/ConcertItem";
+import LoadingIndicator from "@/components/LoadingIndicator";
+import RetryErrorBox from "@/components/commonProfileTab/refetchButton";
 
 function ConcertTab() {
-  const { concertsData, loading, error } = useFetchConcerts();
+  const { data: concertsData, loading, error, refetch } = useFetchConcerts();
 
   if (loading) {
-    return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight={200}
-      >
-        <Typography sx={{ mr: 2 }}>콘서트 정보를 불러오는 중...</Typography>
-        <CircularProgress size={20} />
-      </Box>
-    );
+    return <LoadingIndicator message="콘서트 정보를 불러오는 중입니다..." />;
   }
 
   if (error) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight={200}
-      >
-        <Typography color="error">
-          콘서트 정보를 불러오는 중 오류가 발생했습니다
-        </Typography>
-      </Box>
+      <RetryErrorBox
+        message="콘서트 정보를 불러오는 중 오류가 발생했습니다"
+        onRetry={refetch}
+      />
     );
   }
+
+  if (!concertsData) return null;
 
   // 년도별로 정리 유틸 함수로 분리
   const groupedConcerts = groupConcertsByYear(concertsData);

--- a/src/app/(route)/artist/(tabs)/dramasTab.tsx
+++ b/src/app/(route)/artist/(tabs)/dramasTab.tsx
@@ -1,28 +1,56 @@
-import { getDramaList } from "@/api/profile";
-import { DramaList } from "@/types/iprofile";
-import { Box, Typography } from "@mui/material";
+import useFetchDramas from "@/hooks/useProfileTabApi/useFetchDramas";
+import { Box, CircularProgress, Typography } from "@mui/material";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
-function DramasTab({ inView }: { inView: boolean }) {
-  const [dramas, setDramas] = useState<DramaList[]>([]);
+interface ProfileDramaTabProps {
+  isInView: boolean;
+}
+
+function DramasTab({ isInView }: ProfileDramaTabProps) {
+  const { dramasData, loading, error } = useFetchDramas();
   const isFetched = useRef(false);
 
   useEffect(() => {
-    if (inView && !isFetched.current) {
-      const fetchDramaList = async () => {
-        const dramaList = await getDramaList();
-        setDramas(dramaList);
-        console.log("메롱", dramaList);
-        isFetched.current = true;
-      };
-      fetchDramaList();
+    if (isInView && !isFetched.current) {
+      isFetched.current = true;
     }
-  }, [inView]);
+  }, [isInView]);
+
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight={200}
+      >
+        <Typography sx={{ ml: 2 }}>
+          서버에서 드라마 정보를 불러오는 중...
+        </Typography>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight={200}
+      >
+        <Typography color="error">
+          드라마 정보를 불러오는 중 오류가 발생했습니다
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center">
-      {dramas.map((drama) => (
+      {dramasData.map((drama) => (
         <Box
           key={drama.id}
           sx={{

--- a/src/app/(route)/artist/(tabs)/dramasTab.tsx
+++ b/src/app/(route)/artist/(tabs)/dramasTab.tsx
@@ -1,52 +1,26 @@
+import RetryErrorBox from "@/components/commonProfileTab/refetchButton";
+import LoadingIndicator from "@/components/LoadingIndicator";
 import useFetchDramas from "@/hooks/useProfileTabApi/useFetchDramas";
-import { Box, CircularProgress, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import Image from "next/image";
-import { useEffect, useRef } from "react";
 
-interface ProfileDramaTabProps {
-  isInView: boolean;
-}
-
-function DramasTab({ isInView }: ProfileDramaTabProps) {
-  const { dramasData, loading, error } = useFetchDramas();
-  const isFetched = useRef(false);
-
-  useEffect(() => {
-    if (isInView && !isFetched.current) {
-      isFetched.current = true;
-    }
-  }, [isInView]);
+function DramasTab() {
+  const { data: dramasData, loading, error, refetch } = useFetchDramas();
 
   if (loading) {
-    return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight={200}
-      >
-        <Typography sx={{ ml: 2 }}>
-          서버에서 드라마 정보를 불러오는 중...
-        </Typography>
-        <CircularProgress />
-      </Box>
-    );
+    return <LoadingIndicator message="드라마 정보를 불러오는 중입니다..." />;
   }
 
   if (error) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight={200}
-      >
-        <Typography color="error">
-          드라마 정보를 불러오는 중 오류가 발생했습니다
-        </Typography>
-      </Box>
+      <RetryErrorBox
+        message="드라마 정보를 불러오는 중 오류가 발생했습니다"
+        onRetry={refetch}
+      />
     );
   }
+
+  if (!dramasData) return null;
 
   return (
     <Box display="flex" flexDirection="column" alignItems="center">

--- a/src/app/(route)/artist/(tabs)/profileTabs.tsx
+++ b/src/app/(route)/artist/(tabs)/profileTabs.tsx
@@ -9,7 +9,7 @@ import { motion, AnimatePresence } from "framer-motion";
 
 const tabComponents = {
   album: <AlbumTab />,
-  drama: <DramasTab isInView={true} />,
+  drama: <DramasTab />,
   concert: <ConcertTab />,
   awards: <AwardsTab />,
 };

--- a/src/app/(route)/artist/(tabs)/profileTabs.tsx
+++ b/src/app/(route)/artist/(tabs)/profileTabs.tsx
@@ -7,6 +7,13 @@ import AwardsTab from "./awardsTab";
 import { useInView } from "react-intersection-observer";
 import { motion, AnimatePresence } from "framer-motion";
 
+const tabComponents = {
+  album: <AlbumTab />,
+  drama: <DramasTab isInView={true} />,
+  concert: <ConcertTab />,
+  awards: <AwardsTab />,
+};
+
 const ProfileTabs = () => {
   const [activeTab, setActiveTab] = useState<
     "album" | "drama" | "concert" | "awards"
@@ -37,26 +44,28 @@ const ProfileTabs = () => {
               <Typography variant="h3" fontWeight={600}>
                 Works
               </Typography>
-              <Box
-                sx={{
-                  width: "100%",
-                  mx: "auto",
-                }}
-              >
+
+              <Box>
                 <Tabs
                   value={activeTab}
                   onChange={(_, newValue) => setActiveTab(newValue)}
                   textColor="inherit"
                   sx={{
-                    display: "flex",
-                    justifyContent: "center",
-                    alignItems: "center",
                     width: "100%",
-                    "& .MuiTabs-indicator": { backgroundColor: "#FCC422" },
+                    maxWidth: 600,
                     mb: 6,
                     mt: 2,
+                    "& .MuiTabs-flexContainer": {
+                      display: "flex",
+                      justifyContent: "center",
+                      flexWrap: "wrap",
+                      gap: 1,
+                    },
+                    "& .MuiTabs-indicator": {
+                      backgroundColor: "#FCC422",
+                      transition: "all 0.3s ease",
+                    },
                   }}
-                  centered
                 >
                   {["album", "drama", "concert", "awards"].map((tab) => (
                     <Tab
@@ -64,10 +73,19 @@ const ProfileTabs = () => {
                       value={tab}
                       label={tab.toUpperCase()}
                       sx={{
-                        color: activeTab === tab ? "#FCC422" : "gray",
-                        fontWeight: activeTab === tab ? "bold" : "normal",
-                        transition: "color 0.3s",
-                        minWidth: 100,
+                        textTransform: "none",
+                        fontWeight: activeTab === tab ? 700 : 500,
+                        color: activeTab === tab ? "#FCC422" : "#474747",
+                        fontSize: {
+                          xs: "0.8rem",
+                          sm: "0.9rem",
+                          md: "1rem",
+                        },
+                        width: { xs: "80px", sm: "120px", md: "130px" },
+                        minWidth: "unset",
+                        maxWidth: "unset",
+                        flex: "unset",
+                        textAlign: "center",
                       }}
                     />
                   ))}
@@ -78,38 +96,16 @@ const ProfileTabs = () => {
                 sx={{
                   width: "100%",
                   maxWidth: 800,
-                  display: "flex",
-                  justifyContent: "center",
                 }}
               >
-                {activeTab === "album" && <AlbumTab />}
-                {activeTab === "drama" && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 50 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                  >
-                    <DramasTab inView={inView} />
-                  </motion.div>
-                )}
-                {activeTab === "concert" && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 50 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                  >
-                    <ConcertTab />
-                  </motion.div>
-                )}
-                {activeTab === "awards" && (
-                  <motion.div
-                    initial={{ opacity: 0, y: 50 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                  >
-                    <AwardsTab />
-                  </motion.div>
-                )}
+                <motion.div
+                  key={activeTab}
+                  initial={{ opacity: 0, y: 30 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4 }}
+                >
+                  {tabComponents[activeTab]}
+                </motion.div>
               </Box>
             </Box>
           </motion.div>

--- a/src/app/(route)/artist/page.tsx
+++ b/src/app/(route)/artist/page.tsx
@@ -12,7 +12,7 @@ const Profile = () => {
       flexDirection="column"
       alignItems="center"
       height="100%"
-      paddingBottom={30}
+      paddingBottom={10}
     >
       <ProfileHeader />
       <ProfileInfo />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import HeaderNav from "@/components/headerNav";
 import Footer from "@/components/footer";
 import "./globals.css";
 import SubLayout from "./subLayout";
+import Providers from "./provider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -29,14 +30,16 @@ export default function RootLayout({
     return (
       <html lang="ko">
         <body className={roboto.variable}>
-          <AppRouterCacheProvider>
-            <ThemeProvider theme={theme}>
-              <HeaderNav />
-              {/* <div style={{ marginTop: "100px" }}>{children}</div> */}
-              <SubLayout>{children}</SubLayout>
-              <Footer />
-            </ThemeProvider>
-          </AppRouterCacheProvider>
+          <Providers>
+            <AppRouterCacheProvider>
+              <ThemeProvider theme={theme}>
+                <HeaderNav />
+                {/* <div style={{ marginTop: "100px" }}>{children}</div> */}
+                <SubLayout>{children}</SubLayout>
+                <Footer />
+              </ThemeProvider>
+            </AppRouterCacheProvider>
+          </Providers>
         </body>
       </html>
     );

--- a/src/app/lib/react-query/prefetchAlbums.ts
+++ b/src/app/lib/react-query/prefetchAlbums.ts
@@ -1,0 +1,23 @@
+import { QueryClient } from "@tanstack/react-query";
+import { getAlbumList } from "@/api/discography";
+import { useAlbumStore } from "@/store/albumStore";
+
+export const prefetchAlbums = async (queryClient: QueryClient) => {
+  try {
+    const data = await queryClient.fetchQuery({
+      queryKey: ["profile", "albums"],
+      queryFn: getAlbumList,
+      staleTime: 1000 * 60 * 5, // 5분 캐시
+    }); // zustand에도 저장
+
+    console.log("✅ prefetch된 앨범 데이터:", data);
+    useAlbumStore.getState().setAlbums(data);
+
+    const zustandAlbums = useAlbumStore.getState().albums;
+    console.log("✅ zustand에 저장된 앨범 데이터:", zustandAlbums);
+
+    return data;
+  } catch (error) {
+    console.error("preload 실패:", error);
+  }
+};

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export default function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
+import { prefetchAlbums } from "./lib/react-query/prefetchAlbums";
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
+
+  useEffect(() => {
+    prefetchAlbums(queryClient);
+  }, [queryClient]);
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/components/ErrorIndicator.tsx
+++ b/src/components/ErrorIndicator.tsx
@@ -1,15 +1,15 @@
-import { Box, CircularProgress, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 
-interface LoadingIndicatorProps {
+interface ErrorIndicatorProps {
   message?: string;
   minHeight?: number;
 }
 
-export default function LoadingIndicator({
-  message = "데이터를 불러오는 중입니다...",
+export default function ErrorIndicator({
+  message = "데이터를 불러오는 중 오류가 발생했습니다",
   minHeight = 200,
-}: LoadingIndicatorProps) {
+}: ErrorIndicatorProps) {
   return (
     <Box
       display="flex"
@@ -20,8 +20,7 @@ export default function LoadingIndicator({
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
     >
-      <Typography sx={{ mr: 2 }}>{message}</Typography>
-      <CircularProgress size={24} />
+      <Typography color="error">{message}</Typography>
     </Box>
   );
 }

--- a/src/components/commonAnimation/FadeInUpWrapper.tsx
+++ b/src/components/commonAnimation/FadeInUpWrapper.tsx
@@ -1,0 +1,16 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { ReactNode } from "react";
+
+const FadeInUpWrapper = ({ children }: { children: ReactNode }) => (
+  <AnimatePresence>
+    <motion.div
+      initial={{ opacity: 0, y: 50 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      {children}
+    </motion.div>
+  </AnimatePresence>
+);
+
+export default FadeInUpWrapper;

--- a/src/components/commonProfileTab/AlbumSkeleton.tsx
+++ b/src/components/commonProfileTab/AlbumSkeleton.tsx
@@ -1,0 +1,44 @@
+import { Box } from "@mui/material";
+import Skeleton from "@mui/material/Skeleton";
+
+function AlbumSkeleton() {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexWrap: "wrap",
+        justifyContent: "center",
+        gap: 2,
+        maxWidth: "800px",
+      }}
+    >
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Box
+          key={index}
+          sx={{
+            width: "calc(33.333% - 20px)",
+            minWidth: "200px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            p: 2,
+            borderRadius: 2,
+            bgcolor: "#f0f0f0", // 스켈레톤 배경색
+          }}
+        >
+          <Skeleton
+            variant="rectangular"
+            width={200}
+            height={200}
+            style={{ borderRadius: 8 }}
+          />
+          <Skeleton width="80%" height={16} style={{ marginTop: 8 }} />
+          <Skeleton width="60%" height={14} style={{ marginTop: 4 }} />
+          <Skeleton width="40%" height={12} style={{ marginTop: 4 }} />
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export default AlbumSkeleton;

--- a/src/components/commonProfileTab/AwardItem.tsx
+++ b/src/components/commonProfileTab/AwardItem.tsx
@@ -1,0 +1,28 @@
+import { Typography } from "@mui/material";
+
+interface AwardItemProps {
+  text: string;
+}
+
+function AwardItem({ text }: AwardItemProps) {
+  const [title, subtitle] = text.split(" - ");
+
+  return (
+    <li style={{ marginBottom: "10px" }}>
+      <Typography variant="body2" fontWeight={600}>
+        {title}
+      </Typography>
+      {subtitle && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ fontSize: "0.75rem" }}
+        >
+          {subtitle}
+        </Typography>
+      )}
+    </li>
+  );
+}
+
+export default AwardItem;

--- a/src/components/commonProfileTab/ConcertItem.tsx
+++ b/src/components/commonProfileTab/ConcertItem.tsx
@@ -1,0 +1,26 @@
+import { Typography } from "@mui/material";
+
+interface ConcertItemProps {
+  concertName: string;
+  concertDate: string;
+  place: string;
+}
+
+function ConcertItem({ concertName, concertDate, place }: ConcertItemProps) {
+  return (
+    <li style={{ marginBottom: "10px" }}>
+      <Typography variant="body2" fontWeight={600}>
+        {concertName}
+      </Typography>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ fontSize: "0.75rem" }}
+      >
+        {concertDate} | {place}
+      </Typography>
+    </li>
+  );
+}
+
+export default ConcertItem;

--- a/src/components/commonProfileTab/refetchButton.tsx
+++ b/src/components/commonProfileTab/refetchButton.tsx
@@ -1,0 +1,19 @@
+// components/common/RetryErrorBox.tsx
+import { Button, Box } from "@mui/material";
+import ErrorIndicator from "@/components/ErrorIndicator";
+
+interface Props {
+  message: string;
+  onRetry: () => void;
+}
+
+const RetryErrorBox = ({ message, onRetry }: Props) => (
+  <Box display="flex" flexDirection="column" alignItems="center" mt={4}>
+    <ErrorIndicator message={message} />
+    <Button onClick={onRetry} sx={{ mt: 2 }} variant="outlined">
+      다시 시도
+    </Button>
+  </Box>
+);
+
+export default RetryErrorBox;

--- a/src/components/headerNav.tsx
+++ b/src/components/headerNav.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import useScrollAnimation from "@/utils/scrollUtils";
 import {
   AccountCircle,
-  ShoppingBag,
+  ShoppingCart,
   AdminPanelSettings,
   Menu as MenuIcon,
   Close as CloseIcon,
@@ -62,8 +62,6 @@ function HeaderNav() {
     <>
       <AppBar sx={appBarStyle(scrolling, isMainPage)}>
         <Toolbar sx={{ ...toolbarStyle, justifyContent: "space-between" }}>
-          {" "}
-          {/* justifyContent 변경 */}
           {/* Logo */}
           <Box sx={logoBoxStyle}>
             <Link href="/">
@@ -77,8 +75,6 @@ function HeaderNav() {
             </Link>
           </Box>
           <Box sx={{ display: "flex", alignItems: "center" }}>
-            {" "}
-            {/* 아이콘들을 묶는 Box */}
             {/* Menu Bar for larger screens */}
             <Box
               sx={{
@@ -132,13 +128,11 @@ function HeaderNav() {
                 onClick={() => handleRoute("/cart")}
                 sx={{ ml: 1 }}
               >
-                <ShoppingBag sx={{ color: "#FCC422", fontSize: 30 }} />
+                <ShoppingCart sx={{ color: "#FCC422", fontSize: 30 }} />
               </IconButton>
             </Box>
-            {/* Hamburger Menu for smaller screens (moved to the right) */}
+            {/* Hamburger Menu for smaller screens  */}
             <Box sx={{ display: { xs: "block", md: "none" }, ml: 2 }}>
-              {" "}
-              {/* ml 추가 */}
               <IconButton
                 size="large"
                 edge="end"
@@ -212,7 +206,7 @@ function HeaderNav() {
                 <AccountCircle sx={{ color: "#FCC422", fontSize: 36 }} />
               </IconButton>
               <IconButton onClick={() => handleRoute("/cart")} sx={{ mx: 2 }}>
-                <ShoppingBag sx={{ color: "#FCC422", fontSize: 36 }} />
+                <ShoppingCart sx={{ color: "#FCC422", fontSize: 36 }} />
               </IconButton>
               {roles && roles.includes("ROLE_ADMIN") && (
                 <IconButton onClick={handleAdminPageClick} sx={{ mx: 2 }}>

--- a/src/constants/awardsData.ts
+++ b/src/constants/awardsData.ts
@@ -1,0 +1,29 @@
+export interface AwardGroup {
+  year: string;
+  awards: string[];
+}
+
+export const awardsData: AwardGroup[] = [
+  {
+    year: "2025",
+    awards: ["제1회 디 어워즈 (D Awards) - 임팩트상 수상"],
+  },
+  {
+    year: "2024",
+    awards: [
+      "2024 아시아 아티스트 어워즈 (AAA 2024) - AAA 베스트 초이스상 수상",
+      "2024 아시아 아티스트 어워즈 (AAA 2024) - AAA 이모티브상 수상",
+    ],
+  },
+  {
+    year: "2023",
+    awards: ["2023 대한민국 퍼스트브랜드 - 대상 수상"],
+  },
+  {
+    year: "2022",
+    awards: [
+      "MNET JAPAN FAN’S CHOICE - AWARDS 수상",
+      "SBS MTV 더쇼 - 1위 수상",
+    ],
+  },
+];

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -1,20 +1,3 @@
-// // 직접 최소 로딩 시간 및 타임아웃 시간을 지정하여 사용하는 훅 부분
-// import useFetchProfileData from "./useFetchProfileData";
-// import { getAlbumList } from "@/api/discography";
-// import { Album } from "@/types/iprofile";
-
-// const REQUEST_TIMEOUT = 5000;
-
-// function useFetchAlbums(minLoadingTime: number = 0) {
-//   return useFetchProfileData<Album[]>(
-//     getAlbumList,
-//     minLoadingTime,
-//     REQUEST_TIMEOUT
-//   );
-// }
-
-// export default useFetchAlbums;
-
 // hooks/useProfileTabApi/useFetchAlbums.ts
 import { useQuery } from "@tanstack/react-query";
 import { getAlbumList } from "@/api/discography";

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -1,32 +1,42 @@
-import { useState, useEffect } from "react";
+// import { useState, useEffect } from "react";
+// import { getAlbumList } from "@/api/discography";
+// import { Album } from "@/types/iprofile";
+
+// function useFetchAlbums() {
+//   const [albumsData, setAlbumsData] = useState<Album[]>([]);
+//   const [loading, setLoading] = useState(true);
+//   const [error, setError] = useState<Error | null>(null);
+
+//   useEffect(() => {
+//     const fetchAlbums = async () => {
+//       try {
+//         const albumList = await getAlbumList();
+//         setAlbumsData(albumList);
+//         setLoading(false);
+//       } catch (error: unknown) {
+//         if (error instanceof Error) {
+//           setError(error);
+//         } else {
+//           setError(new Error("Unknown error occurred"));
+//         }
+//         setLoading(false);
+//       }
+//     };
+
+//     fetchAlbums();
+//   }, []);
+
+//   return { albumsData, loading, error };
+// }
+
+// export default useFetchAlbums;
+
+import useFetchData from "./useFetchData";
 import { getAlbumList } from "@/api/discography";
 import { Album } from "@/types/iprofile";
 
 function useFetchAlbums() {
-  const [albumsData, setAlbumsData] = useState<Album[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    const fetchAlbums = async () => {
-      try {
-        const albumList = await getAlbumList();
-        setAlbumsData(albumList);
-        setLoading(false);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          setError(error);
-        } else {
-          setError(new Error("Unknown error occurred"));
-        }
-        setLoading(false);
-      }
-    };
-
-    fetchAlbums();
-  }, []);
-
-  return { albumsData, loading, error };
+  return useFetchData<Album[]>(getAlbumList);
 }
 
 export default useFetchAlbums;

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { getAlbumList } from "@/api/discography";
+import { Album } from "@/types/iprofile";
+
+function useFetchAlbums() {
+  const [albumsData, setAlbumsData] = useState<Album[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchAlbums = async () => {
+      try {
+        const albumList = await getAlbumList();
+        setAlbumsData(albumList);
+        setLoading(false);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setError(error);
+        } else {
+          setError(new Error("Unknown error occurred"));
+        }
+        setLoading(false);
+      }
+    };
+
+    fetchAlbums();
+  }, []);
+
+  return { albumsData, loading, error };
+}
+
+export default useFetchAlbums;

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -9,6 +9,7 @@ const REQUEST_TIMEOUT = 5000;
 function useFetchAlbums(minLoadingTime: number = 0) {
   // zustand와 동기화하기
   const setAlbums = useAlbumStore((state) => state.setAlbums);
+  const albumStoreData = useAlbumStore((state) => state.albums);
 
   return useQuery<Album[]>({
     queryKey: ["profile", "albums"], // 캐시 키
@@ -30,9 +31,9 @@ function useFetchAlbums(minLoadingTime: number = 0) {
 
       // 💾 상태 저장
       setAlbums(result);
-
       return result;
     },
+    initialData: albumStoreData ?? undefined,
     staleTime: 1000 * 60 * 5, // 5분 동안은 새로 요청 안 함
     retry: 0, // 실패 시 1회 자동 재시도
     // api 요청이 실패한 상태일 때, 탭을 다시 들어오거나 alt-tab-> 이후에 자동으로 refetch 중이었음

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -31,12 +31,12 @@
 
 // export default useFetchAlbums;
 
-import useFetchData from "./useFetchProfileData";
+import useFetchProfileData from "./useFetchProfileData";
 import { getAlbumList } from "@/api/discography";
 import { Album } from "@/types/iprofile";
 
-function useFetchAlbums() {
-  return useFetchData<Album[]>(getAlbumList);
+function useFetchAlbums(minLoadingTime: number = 0) {
+  return useFetchProfileData<Album[]>(getAlbumList, minLoadingTime);
 }
 
 export default useFetchAlbums;

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -1,48 +1,52 @@
-// import { useState, useEffect } from "react";
+// // 직접 최소 로딩 시간 및 타임아웃 시간을 지정하여 사용하는 훅 부분
+// import useFetchProfileData from "./useFetchProfileData";
 // import { getAlbumList } from "@/api/discography";
 // import { Album } from "@/types/iprofile";
 
-// function useFetchAlbums() {
-//   const [albumsData, setAlbumsData] = useState<Album[]>([]);
-//   const [loading, setLoading] = useState(true);
-//   const [error, setError] = useState<Error | null>(null);
+// const REQUEST_TIMEOUT = 5000;
 
-//   useEffect(() => {
-//     const fetchAlbums = async () => {
-//       try {
-//         const albumList = await getAlbumList();
-//         setAlbumsData(albumList);
-//         setLoading(false);
-//       } catch (error: unknown) {
-//         if (error instanceof Error) {
-//           setError(error);
-//         } else {
-//           setError(new Error("Unknown error occurred"));
-//         }
-//         setLoading(false);
-//       }
-//     };
-
-//     fetchAlbums();
-//   }, []);
-
-//   return { albumsData, loading, error };
+// function useFetchAlbums(minLoadingTime: number = 0) {
+//   return useFetchProfileData<Album[]>(
+//     getAlbumList,
+//     minLoadingTime,
+//     REQUEST_TIMEOUT
+//   );
 // }
 
 // export default useFetchAlbums;
 
-import useFetchProfileData from "./useFetchProfileData";
+// hooks/useProfileTabApi/useFetchAlbums.ts
+import { useQuery } from "@tanstack/react-query";
 import { getAlbumList } from "@/api/discography";
 import { Album } from "@/types/iprofile";
 
-const REQUEST_TIMEOUT = 4000;
+const REQUEST_TIMEOUT = 5000;
 
 function useFetchAlbums(minLoadingTime: number = 0) {
-  return useFetchProfileData<Album[]>(
-    getAlbumList,
-    minLoadingTime,
-    REQUEST_TIMEOUT
-  );
+  return useQuery<Album[]>({
+    queryKey: ["profile", "albums"], // 캐시 키
+    queryFn: async () => {
+      const start = Date.now();
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(() => {
+          reject(new Error("요청 시간이 초과되었습니다."));
+        }, REQUEST_TIMEOUT)
+      );
+      const dataPromise = getAlbumList();
+
+      const result = await Promise.race([dataPromise, timeoutPromise]);
+
+      const elapsed = Date.now() - start;
+      if (elapsed < minLoadingTime) {
+        await new Promise((res) => setTimeout(res, minLoadingTime - elapsed));
+      }
+      return result;
+    },
+    staleTime: 1000 * 60 * 5, // 5분 동안은 새로 요청 안 함
+    retry: 0, // 실패 시 1회 자동 재시도
+    // api 요청이 실패한 상태일 때, 탭을 다시 들어오거나 alt-tab-> 이후에 자동으로 refetch 중이었음
+    refetchOnWindowFocus: false,
+  });
 }
 
 export default useFetchAlbums;

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -19,10 +19,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { getAlbumList } from "@/api/discography";
 import { Album } from "@/types/iprofile";
+import { useAlbumStore } from "@/store/albumStore";
 
 const REQUEST_TIMEOUT = 5000;
 
 function useFetchAlbums(minLoadingTime: number = 0) {
+  // zustand와 동기화하기
+  const setAlbums = useAlbumStore((state) => state.setAlbums);
+
   return useQuery<Album[]>({
     queryKey: ["profile", "albums"], // 캐시 키
     queryFn: async () => {
@@ -40,6 +44,10 @@ function useFetchAlbums(minLoadingTime: number = 0) {
       if (elapsed < minLoadingTime) {
         await new Promise((res) => setTimeout(res, minLoadingTime - elapsed));
       }
+
+      // 💾 상태 저장
+      setAlbums(result);
+
       return result;
     },
     staleTime: 1000 * 60 * 5, // 5분 동안은 새로 요청 안 함

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -35,8 +35,14 @@ import useFetchProfileData from "./useFetchProfileData";
 import { getAlbumList } from "@/api/discography";
 import { Album } from "@/types/iprofile";
 
+const REQUEST_TIMEOUT = 4000;
+
 function useFetchAlbums(minLoadingTime: number = 0) {
-  return useFetchProfileData<Album[]>(getAlbumList, minLoadingTime);
+  return useFetchProfileData<Album[]>(
+    getAlbumList,
+    minLoadingTime,
+    REQUEST_TIMEOUT
+  );
 }
 
 export default useFetchAlbums;

--- a/src/hooks/useProfileTabApi/useFetchAlbum.ts
+++ b/src/hooks/useProfileTabApi/useFetchAlbum.ts
@@ -31,7 +31,7 @@
 
 // export default useFetchAlbums;
 
-import useFetchData from "./useFetchData";
+import useFetchData from "./useFetchProfileData";
 import { getAlbumList } from "@/api/discography";
 import { Album } from "@/types/iprofile";
 

--- a/src/hooks/useProfileTabApi/useFetchConcerts.ts
+++ b/src/hooks/useProfileTabApi/useFetchConcerts.ts
@@ -1,32 +1,42 @@
-import { useState, useEffect } from "react";
+// import { useState, useEffect } from "react";
+// import { getConcertList } from "@/api/profile";
+// import { ConcertList } from "@/types/iprofile";
+
+// function useFetchConcerts() {
+//   const [concertsData, setConcertsData] = useState<ConcertList[]>([]);
+//   const [loading, setLoading] = useState(true);
+//   const [error, setError] = useState<Error | null>(null);
+
+//   useEffect(() => {
+//     const fetchConcerts = async () => {
+//       try {
+//         const concertList = await getConcertList();
+//         setConcertsData(concertList);
+//         setLoading(false);
+//       } catch (error: unknown) {
+//         if (error instanceof Error) {
+//           setError(error);
+//         } else {
+//           setError(new Error("Unknown error occurred"));
+//         }
+//         setLoading(false);
+//       }
+//     };
+
+//     fetchConcerts();
+//   }, []);
+
+//   return { concertsData, loading, error };
+// }
+
+// export default useFetchConcerts;
+
+import useFetchData from "./useFetchData";
 import { getConcertList } from "@/api/profile";
 import { ConcertList } from "@/types/iprofile";
 
 function useFetchConcerts() {
-  const [concertsData, setConcertsData] = useState<ConcertList[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    const fetchConcerts = async () => {
-      try {
-        const concertList = await getConcertList();
-        setConcertsData(concertList);
-        setLoading(false);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          setError(error);
-        } else {
-          setError(new Error("Unknown error occurred"));
-        }
-        setLoading(false);
-      }
-    };
-
-    fetchConcerts();
-  }, []);
-
-  return { concertsData, loading, error };
+  return useFetchData<ConcertList[]>(getConcertList);
 }
 
 export default useFetchConcerts;

--- a/src/hooks/useProfileTabApi/useFetchConcerts.ts
+++ b/src/hooks/useProfileTabApi/useFetchConcerts.ts
@@ -31,12 +31,12 @@
 
 // export default useFetchConcerts;
 
-import useFetchData from "./useFetchProfileData";
+import useFetchProfileData from "./useFetchProfileData";
 import { getConcertList } from "@/api/profile";
 import { ConcertList } from "@/types/iprofile";
 
 function useFetchConcerts() {
-  return useFetchData<ConcertList[]>(getConcertList);
+  return useFetchProfileData<ConcertList[]>(getConcertList);
 }
 
 export default useFetchConcerts;

--- a/src/hooks/useProfileTabApi/useFetchConcerts.ts
+++ b/src/hooks/useProfileTabApi/useFetchConcerts.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { getConcertList } from "@/api/profile";
+import { ConcertList } from "@/types/iprofile";
+
+function useFetchConcerts() {
+  const [concertsData, setConcertsData] = useState<ConcertList[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchConcerts = async () => {
+      try {
+        const concertList = await getConcertList();
+        setConcertsData(concertList);
+        setLoading(false);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setError(error);
+        } else {
+          setError(new Error("Unknown error occurred"));
+        }
+        setLoading(false);
+      }
+    };
+
+    fetchConcerts();
+  }, []);
+
+  return { concertsData, loading, error };
+}
+
+export default useFetchConcerts;

--- a/src/hooks/useProfileTabApi/useFetchConcerts.ts
+++ b/src/hooks/useProfileTabApi/useFetchConcerts.ts
@@ -31,7 +31,7 @@
 
 // export default useFetchConcerts;
 
-import useFetchData from "./useFetchData";
+import useFetchData from "./useFetchProfileData";
 import { getConcertList } from "@/api/profile";
 import { ConcertList } from "@/types/iprofile";
 

--- a/src/hooks/useProfileTabApi/useFetchData.ts
+++ b/src/hooks/useProfileTabApi/useFetchData.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useCallback } from "react";
+
+function useFetchData<T>(fetchFunction: () => Promise<T>) {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetchFunction();
+      setData(response);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err);
+      } else {
+        setError(new Error("Unknown error occurred"));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchFunction]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, refetch: fetchData };
+}
+
+export default useFetchData;

--- a/src/hooks/useProfileTabApi/useFetchDramas.ts
+++ b/src/hooks/useProfileTabApi/useFetchDramas.ts
@@ -1,32 +1,42 @@
-import { useState, useEffect } from "react";
+// import { useState, useEffect } from "react";
+// import { getDramaList } from "@/api/profile";
+// import { DramaList } from "@/types/iprofile";
+
+// function useFetchDramas() {
+//   const [dramasData, setDramasData] = useState<DramaList[]>([]);
+//   const [loading, setLoading] = useState(true);
+//   const [error, setError] = useState<Error | null>(null);
+
+//   useEffect(() => {
+//     const fetchDramas = async () => {
+//       try {
+//         const dramaList = await getDramaList();
+//         setDramasData(dramaList);
+//         setLoading(false);
+//       } catch (error: unknown) {
+//         if (error instanceof Error) {
+//           setError(error);
+//         } else {
+//           setError(new Error("Unknown error occurred"));
+//         }
+//         setLoading(false);
+//       }
+//     };
+
+//     fetchDramas();
+//   }, []);
+
+//   return { dramasData, loading, error };
+// }
+
+// export default useFetchDramas;
+
+import useFetchData from "./useFetchData";
 import { getDramaList } from "@/api/profile";
 import { DramaList } from "@/types/iprofile";
 
 function useFetchDramas() {
-  const [dramasData, setDramasData] = useState<DramaList[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    const fetchDramas = async () => {
-      try {
-        const dramaList = await getDramaList();
-        setDramasData(dramaList);
-        setLoading(false);
-      } catch (error: unknown) {
-        if (error instanceof Error) {
-          setError(error);
-        } else {
-          setError(new Error("Unknown error occurred"));
-        }
-        setLoading(false);
-      }
-    };
-
-    fetchDramas();
-  }, []);
-
-  return { dramasData, loading, error };
+  return useFetchData<DramaList[]>(getDramaList);
 }
 
 export default useFetchDramas;

--- a/src/hooks/useProfileTabApi/useFetchDramas.ts
+++ b/src/hooks/useProfileTabApi/useFetchDramas.ts
@@ -31,7 +31,7 @@
 
 // export default useFetchDramas;
 
-import useFetchData from "./useFetchData";
+import useFetchData from "./useFetchProfileData";
 import { getDramaList } from "@/api/profile";
 import { DramaList } from "@/types/iprofile";
 

--- a/src/hooks/useProfileTabApi/useFetchDramas.ts
+++ b/src/hooks/useProfileTabApi/useFetchDramas.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { getDramaList } from "@/api/profile";
+import { DramaList } from "@/types/iprofile";
+
+function useFetchDramas() {
+  const [dramasData, setDramasData] = useState<DramaList[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchDramas = async () => {
+      try {
+        const dramaList = await getDramaList();
+        setDramasData(dramaList);
+        setLoading(false);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          setError(error);
+        } else {
+          setError(new Error("Unknown error occurred"));
+        }
+        setLoading(false);
+      }
+    };
+
+    fetchDramas();
+  }, []);
+
+  return { dramasData, loading, error };
+}
+
+export default useFetchDramas;

--- a/src/hooks/useProfileTabApi/useFetchDramas.ts
+++ b/src/hooks/useProfileTabApi/useFetchDramas.ts
@@ -31,12 +31,12 @@
 
 // export default useFetchDramas;
 
-import useFetchData from "./useFetchProfileData";
+import useFetchProfileData from "./useFetchProfileData";
 import { getDramaList } from "@/api/profile";
 import { DramaList } from "@/types/iprofile";
 
 function useFetchDramas() {
-  return useFetchData<DramaList[]>(getDramaList);
+  return useFetchProfileData<DramaList[]>(getDramaList);
 }
 
 export default useFetchDramas;

--- a/src/hooks/useProfileTabApi/useFetchProfileData.ts
+++ b/src/hooks/useProfileTabApi/useFetchProfileData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 
-function useFetchData<T>(fetchFunction: () => Promise<T>) {
+function useFetchProfileData<T>(fetchFunction: () => Promise<T>) {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -30,4 +30,4 @@ function useFetchData<T>(fetchFunction: () => Promise<T>) {
   return { data, loading, error, refetch: fetchData };
 }
 
-export default useFetchData;
+export default useFetchProfileData;

--- a/src/hooks/useProfileTabApi/useFetchProfileData.ts
+++ b/src/hooks/useProfileTabApi/useFetchProfileData.ts
@@ -1,17 +1,46 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 
-function useFetchProfileData<T>(fetchFunction: () => Promise<T>) {
+function useFetchProfileData<T>(
+  fetchFunction: () => Promise<T>,
+  // 최소 로딩 시간 (ms)
+  minLoadingTime: number = 0
+) {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  // 타이머 직접 설정
+  const loadingTimer = useRef<NodeJS.Timeout | null>(null);
+  const hasFetched = useRef(false); // 첫 데이터 로딩 완료 여부 추적
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
 
+    // 시작 시간 받기
+    const startTime = Date.now();
+
     try {
       const response = await fetchFunction();
       setData(response);
+      // 데이터 로딩 성공
+      hasFetched.current = true;
+
+      const endTime = Date.now();
+      const elapsedTime = endTime - startTime;
+
+      if (elapsedTime < minLoadingTime) {
+        //최소 로딩 시간보다 짧게 걸리면, 남은 시간만큼 딜레이 후 로딩 상태 해제
+        await new Promise(
+          (resolve) =>
+            (loadingTimer.current = setTimeout(
+              resolve,
+              minLoadingTime - elapsedTime
+            ))
+        );
+        setLoading(false);
+      } else {
+        setLoading(false);
+      }
     } catch (err: unknown) {
       if (err instanceof Error) {
         setError(err);
@@ -19,9 +48,14 @@ function useFetchProfileData<T>(fetchFunction: () => Promise<T>) {
         setError(new Error("Unknown error occurred"));
       }
     } finally {
-      setLoading(false);
+      if (loadingTimer.current) {
+        clearTimeout(loadingTimer.current);
+      }
+      if (!hasFetched.current) {
+        setLoading(false);
+      }
     }
-  }, [fetchFunction]);
+  }, [fetchFunction, minLoadingTime]);
 
   useEffect(() => {
     fetchData();

--- a/src/hooks/useProfileTabApi/useFetchProfileData.ts
+++ b/src/hooks/useProfileTabApi/useFetchProfileData.ts
@@ -25,8 +25,12 @@ function useFetchProfileData<T>(
 
     // 타임아웃 설정하기
     timeoutTimer.current = setTimeout(() => {
-      setLoading(false);
-      setError(new Error("요청 시간 초과되었습니다. 다시 시도해주세요."));
+      // 이미 데이터를 가져왔다면 에러 상태를 업데이트하지 않음
+      if (!hasFetched.current) {
+        setLoading(false);
+        setError(new Error("요청 시간 초과되었습니다. 다시 시도해주세요."));
+      }
+      // 타임아웃 발생 시 hasFetched를 true로 설정하지 않음.
     }, timeout);
 
     try {
@@ -57,15 +61,13 @@ function useFetchProfileData<T>(
       } else {
         setError(new Error("알 수 없는 오류가 발생했습니다."));
       }
+      setLoading(false);
     } finally {
       if (loadingTimer.current) {
         clearTimeout(loadingTimer.current);
       }
       if (timeoutTimer.current) {
         clearTimeout(timeoutTimer.current);
-      }
-      if (!hasFetched.current) {
-        setLoading(false);
       }
     }
   }, [fetchFunction, minLoadingTime, timeout]);

--- a/src/store/albumStore.ts
+++ b/src/store/albumStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { Album } from "@/types/iprofile";
+
+interface AlbumState {
+  albums: Album[] | null;
+  setAlbums: (albums: Album[]) => void;
+}
+
+export const useAlbumStore = create<AlbumState>((set) => ({
+  albums: null,
+  setAlbums: (albums) => set({ albums }),
+}));

--- a/src/types/iprofile.ts
+++ b/src/types/iprofile.ts
@@ -27,12 +27,7 @@ export interface DramaImage {
 export interface ConcertList {
   id: number;
   concertName: string;
-  concertDate: number;
+  concertDate: string;
+  // concertDate: number;
   place: string;
-  // concertImages: ConcertImage[];
-  // imageUrl: string;
 }
-// export interface ConcertImage {
-//   id: number;
-//   url: string;
-// }

--- a/src/utils/groupConcertsByYear.ts
+++ b/src/utils/groupConcertsByYear.ts
@@ -1,0 +1,22 @@
+import { ConcertList } from "@/types/iprofile";
+
+// 정의해둔 콘서트 인터페이스를 연도별 그룹화된 객체로 한번 더 정의
+interface GroupedConcerts {
+  [year: string]: ConcertList[];
+}
+
+function groupConcertsByYear(concerts: ConcertList[]): GroupedConcerts {
+  // 콘서트 배열을 하나의 객체로 변환
+  // acc는 누적되는 결과값 (초기값은 {}), concert는 배열의 각 요소
+  return concerts.reduce((acc, concert) => {
+    // '년도' 숫자 추출 후 문자열로 변환 (객체의 key)
+    const year = new Date(concert.concertDate).getFullYear().toString();
+    // acc객체에 year 키가 없으면 빈 배열 생성
+    if (!acc[year]) acc[year] = [];
+    // 해당 연도 배열에 콘서트 추가
+    acc[year].push(concert);
+    return acc;
+  }, {} as GroupedConcerts);
+}
+
+export default groupConcertsByYear;


### PR DESCRIPTION
1. **_프로필 컴포넌트 모듈화 및 분리_**
1-1. 애니메이션 컴포넌트 공통화
1-2. fetch api hook 분리
1-3. 콘서트 탭 정보 수상 정보 UI와 비슷하게 수정 및 연도별 배열 생성 유틸함수

2. **_앨범, 콘서트, 드라마 api 공통 hook으로 관리 및 컴포넌트 간소화_**
2-1. 해당 과정에서 로딩 및 에러 인디케이터 -> refetch 버튼 제작
2-2. 이후 문제 발생: 결과에 상관없이 로딩 시간의 일정함 , refetch 버튼 나타나는 에러 발생
2-3. 초기에는 최소 로딩 시간(MIN_LOADINGTIME)및 타임아웃(timeout)을 직접 설정 후 에러 해결

3. **_이후 react-query를 도입해 캐시 전략 구현_**
3-1. useQuery를 통해 캐시 전략 도입 이때, 기존에 설정한 최소로딩시간이라거나 타임아웃을 커스텀함수로 구현
3-2. 이전에는 직접 설정해둔 timeout을 promise.race( ) 메서드를 사용해 더 향상된 UX를 제공 

4. _**캐시 전략 도입 후, 기존에 전역상태툴인 zustand 스토어와 (우선은)앨범리스트를 연동**_
4-1. 하지만 이 때, 해당 페이지까지 접속하지 않으면 함수가 실행되지 않아 저장되지 않고, 애매한 UX 제공 문제
4-2. 그러면 해당 페이지에 접속하기 전에 prefetch 기능을 전역에서 실행해서 zustand 스토어에 담고 이후 기능을 확장해 나가자
4-3. 추가로 원래 사용하던 훅에는 초기 데이터를 zustand에서 꺼내와 사용할 수도 있다라는 걸 추가 명시

5. **이후 해봐야할 것들(리팩토링 예정)**
5-1. 기존에 최소 로딩 시간 및 타임아웃 직접 설정한 상태와 useQuery를 이용한 캐시 전략을 도입하면서 커스텀 훅으로 promise.race( )를 적용한 타임아웃 기능의 성능 차이 측정 및 계산해보기 (궁금함)
5-2. 현재는 앨범 탭에만 적용되어있는 캐시전략 및 prefetch 기능 추후 콘서트 및 드라마 탭에도 구현 및 공통 훅으로 관리하기(모듈화)
5-3. 현재는 단순히 CRUD의 기능에서 UX 향상을 위한 기능만 구현되어 있는 상태인데, 이제는 prefetch 기능 및 zustand에 전역상태로 저장됨에 따라 이를 통해 확장해 나갈 기능들을 모색 및 적용할 수 있음. 예를 들어) 1) 앨범 상세 페이지, 2) 다른 페이지에서 미리보기로 사용 가능, 3) 오프라인 뷰 기능, 4) 타임라인 기능 등등 다양한 가능성 생김

Close #81 

